### PR TITLE
koe: use symbol form for depends_on macos

### DIFF
--- a/Casks/koe.rb
+++ b/Casks/koe.rb
@@ -8,7 +8,7 @@ cask "koe" do
   homepage "https://github.com/missuo/koe"
 
   depends_on arch: :arm64
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   app "Koe.app"
   binary "#{appdir}/Koe.app/Contents/MacOS/koe-cli", target: "koe"


### PR DESCRIPTION
## What

Change the `koe` cask's macOS requirement from the deprecated string-comparison form to the symbol form:

```diff
- depends_on macos: ">= :ventura"
+ depends_on macos: :ventura
```

## Why

Running any `brew` command that touches this tap currently prints a deprecation warning:

```
Warning: Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :ventura` instead.
Please report this issue to the owo-network/homebrew-brew tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
  .../owo-network/homebrew-brew/Casks/koe.rb:11
```

`depends_on macos: :ventura` already means "Ventura or newer", so this is behavior-preserving — `brew info --cask koe` still reports `macOS >= 13`.

## Verification

- `brew style Casks/koe.rb` no longer reports any offense on the `depends_on macos` line (the remaining unrelated style offenses in this file are pre-existing and left untouched to keep this PR minimal).
- The deprecation warning is gone after the change.