### PR TITLE
fix: use symbol form for depends_on macos in polyglot-sub and imgzip

### DIFF
--- a/Casks/imgzip.rb
+++ b/Casks/imgzip.rb
@@ -15,7 +15,7 @@ cask "imgzip" do
   desc "A simple and efficient image compression tool"
   homepage "https://github.com/missuo/imgzip"
   
-  depends_on macos: ">= :catalina"
+  depends_on macos: :catalina
   postflight do
     system "xattr", "-d", "com.apple.quarantine", "#{HOMEBREW_PREFIX}/bin/imgzip"
   end

--- a/Casks/polyglot-sub.rb
+++ b/Casks/polyglot-sub.rb
@@ -8,7 +8,7 @@ cask "polyglot-sub" do
   homepage "https://github.com/missuo/PolyglotSub"
 
   auto_updates true
-  depends_on macos: ">= :monterey"
+  depends_on macos: :monterey
 
   app "Polyglot Sub.app"
 


### PR DESCRIPTION
## What

Fix the deprecated string-comparison format for `depends_on macos:` in the remaining two casks (polyglot-sub and imgzip):

```diff
- depends_on macos: ">= :monterey"
+ depends_on macos: :monterey

- depends_on macos: ">= :catalina"
+ depends_on macos: :catalina
```

## Why

Running any `brew` command that touches this tap currently prints deprecation warnings:

```
Warning: Calling string comparison format for depends_on macos: is deprecated!
  .../owo-network/homebrew-brew/Casks/polyglot-sub.rb:11
  .../owo-network/homebrew-brew/Casks/imgzip.rb:18
```

The symbol form (`:monterey`, `:catalina`) already means "this version or newer", so this is behavior-preserving.

## Scope

- `Casks/polyglot-sub.rb`: `>= :monterey` -> `:monterey`
- `Casks/imgzip.rb`: `>= :catalina` -> `:catalina`
- `Casks/koe.rb`: **not touched** -- already covered by PR #4
- `Casks/mist.rb`: no deprecated format, no change needed

## Verification

- `brew style Casks/polyglot-sub.rb` -- no deprecation warning on `depends_on macos`
- `brew style Casks/imgzip.rb` -- no deprecation warning on `depends_on macos`